### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<!-- release> -->
-		<matsim.version>11.0</matsim.version>
+		<!-- <matsim.version>11.0</matsim.version> -->
 
 		<!--weekly "release":-->
 		<!--<matsim.version>0.11.0-2019w01-SNAPSHOT</matsim.version>-->
@@ -26,7 +26,8 @@
 			<!-- Geotools is not on Maven central -->
 			<id>osgeo</id>
 			<name>Geotools repository</name>
-			<url>http://download.osgeo.org/webdav/geotools</url>
+			<!-- <url>http://download.osgeo.org/webdav/geotools</url> -->
+			<url>https://repo.osgeo.org/repository/release/</url>
 		</repository>
 		<repository>
 			<!-- Repository for MATSim releases (MATSim is not on Maven central) -->


### PR DESCRIPTION
remove double dependency entry for matsim version and update goetools repo after their apparent move