### PR TITLE
Update matsim dependency to release 14.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,16 +11,13 @@
 
 	<properties>
 		<!-- release -->
-		<matsim.version>13.0</matsim.version>
-
-		<!-- weekly release -->
-<!--		<matsim.version>14.0-2021w43</matsim.version>-->
+		<matsim.version>14.0</matsim.version>
 
 		<!-- PR release -->
-		<!--		<matsim.version>13.1-PR1536</matsim.version>-->
+		<!--		<matsim.version>13.1-PR1536</matsim.version> -->
 
 		<!-- for dependency sharing in IDE -->
-<!--				<matsim.version>14.0-SNAPSHOT</matsim.version>-->
+		<!--		<matsim.version>14.0-SNAPSHOT</matsim.version> -->
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Also remove example on how to point to weekly release, since we use the pr releases now.