### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,4 +26,4 @@ jobs:
           cache: 'maven'
 
       - name: Run mvn verify
-        run: mvn -B verify
+        run: mvn -B verify -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.